### PR TITLE
BIND view support

### DIFF
--- a/templates/etc/bind/named.conf.local.j2
+++ b/templates/etc/bind/named.conf.local.j2
@@ -23,12 +23,11 @@ view "{{ view }}" {
 {% for zone,content in content.zones.iteritems() | sort %}
  zone "{{ zone }}" {
 {%   for param,value in content.iteritems() | sort %}
- {{ param }} {{ value }};
+   {{ param }} {{ value }};
 {%   endfor %}
   };
 {%  endfor %}
 
-};
 {% endif %}
 };
 {% endfor %}


### PR DESCRIPTION
cleaning up this template, removing accidental repeated `};`.